### PR TITLE
Have shortcut card creation gh action fill more fields

### DIFF
--- a/.github/workflows/shortcut-create.yml
+++ b/.github/workflows/shortcut-create.yml
@@ -13,3 +13,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           shortcut-token: ${{ secrets.SHORTCUT_TOKEN }}
           project-name: app.gograyscale.com
+          opened-state-name: PR Open
+          merged-state-name: Ready for QA

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,8 @@ inputs:
   project-name:
     description: The name of the Shortcut.com project to create stories in
     required: true
+  team-name:
+    description: The name of the Shortcut team to assign to the new story.
   opened-state-name:
     description: The name of the workflow state for Shortcut stories when a pull request is created.
   closed-state-name:

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,18 @@ export interface ShortcutProject {
   updated_at: string | null;
 }
 
+/** Maps to a 'team' in the Shortcut UI */
+export interface ShortcutGroup {
+  app_url: string;
+  archived: boolean;
+  color: string | null;
+  color_key: string | null;
+  description: string;
+  entity_type: "group";
+  id: string;
+  name: string;
+}
+
 /** Group of Projects with the same Workflow. */
 export interface ShortcutTeam {
   entity_type: "team";
@@ -304,6 +316,7 @@ export interface ShortcutStory {
   external_links: string[];
   files: ShortcutFile[];
   follower_ids: string[];
+  group_id: string | null;
   group_mention_ids: string[];
   id: number;
   iteration_id: number | null;
@@ -375,6 +388,7 @@ export interface ShortcutCreateStoryBody {
   external_links?: string[];
   file_ids?: number[];
   follower_ids?: string[];
+  group_id?: string | null;
   iteration_id?: number | null;
   labels?: ShortcutCreateLabelParams[];
   linked_file_ids?: number[];


### PR DESCRIPTION
## Description of the change

Add a new team-name input that can be used to set the SC team. The team-name input is optional; when set and a matching Shortcut Team is found, that team wil be assigned to the newly created story.

For our own repo, fill in some of the opened/merged state names to populate those on open/merge.
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] Schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] All UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] The code changed/added does not introduce security vulnerabilities

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] At least one other engineer confirms that schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] At least one other engineer confirms that all UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] At least one other engineer has confirmed that the code changed/added will not introduce security vulnerabilities
- [ ] Issue from task tracker has a link to this pull request
